### PR TITLE
More explicit typing, bumped version number

### DIFF
--- a/components/captcha.ts
+++ b/components/captcha.ts
@@ -20,7 +20,7 @@ export class ReCaptchaComponent implements OnInit {
     language: string = null;
 
     @Output()
-    captchaResponse:EventEmitter<string>;
+    captchaResponse: EventEmitter<string>;
 
     constructor(zone: NgZone) {
         window[<any>"verifyCallback"] = <any>((response: any) => zone.run(this.recaptchaCallback.bind(this, response)));

--- a/components/captcha.ts
+++ b/components/captcha.ts
@@ -14,20 +14,17 @@ import {
 export class ReCaptchaComponent implements OnInit {
 
     @Input()
-    site_key: string = null;
-    /* Available languages: https://developers.google.com/recaptcha/docs/language */
-    @Input()
-    language: string = null;
+    site_key:string = null;
 
     @Output()
-    captchaResponse: EventEmitter<string>;
+    captchaResponse:EventEmitter<string>;
 
-    constructor(private _zone: NgZone) {
-        window['verifyCallback'] = (response: any) => this._zone.run(this.recaptchaCallback.bind(this, response));
+    constructor(zone: NgZone) {
+        window[<any>"verifyCallback"] = <any>((response: any) => zone.run(this.recaptchaCallback.bind(this, response)));
         this.captchaResponse = new EventEmitter<string>();
     }
 
-    recaptchaCallback(response) {
+    recaptchaCallback(response: string) {
         this.captchaResponse.emit(response);
     }
 
@@ -35,7 +32,7 @@ export class ReCaptchaComponent implements OnInit {
         var doc = <HTMLDivElement> document.body;
         var script = document.createElement('script');
         script.innerHTML = '';
-        script.src = 'https://www.google.com/recaptcha/api.js' + (this.language ? '?hl=' + this.language : '');
+        script.src = 'https://www.google.com/recaptcha/api.js';
         script.async = true;
         script.defer = true;
         doc.appendChild(script);

--- a/components/captcha.ts
+++ b/components/captcha.ts
@@ -14,7 +14,10 @@ import {
 export class ReCaptchaComponent implements OnInit {
 
     @Input()
-    site_key:string = null;
+    site_key: string = null;
+    /* Available languages: https://developers.google.com/recaptcha/docs/language */
+    @Input()
+    language: string = null;
 
     @Output()
     captchaResponse:EventEmitter<string>;
@@ -32,7 +35,7 @@ export class ReCaptchaComponent implements OnInit {
         var doc = <HTMLDivElement> document.body;
         var script = document.createElement('script');
         script.innerHTML = '';
-        script.src = 'https://www.google.com/recaptcha/api.js';
+        script.src = 'https://www.google.com/recaptcha/api.js' + (this.language ? '?hl=' + this.language : '');
         script.async = true;
         script.defer = true;
         doc.appendChild(script);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-recaptcha",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Angular 2 : Typescript component for Google reCaptcha",
   "main": "angular2-recaptcha.js",
   "scripts": {
@@ -20,7 +20,7 @@
     "url": "https://github.com/xmaestro/angular2-recaptcha/issues"
   },
   "peerDependencies": {
-    "@angular/core": "2.0.0-rc.3"
+    "@angular/core": "^2.0.0-rc.2"
   },
   "homepage": "https://github.com/xmaestro/angular2-recaptcha#readme"
 }


### PR DESCRIPTION
According to http://stackoverflow.com/questions/36316326/typescript-ts7015-error-when-accessing-an-enum-using-a-string-type-parameter this should fix the typing error. Made typing more explicit and changed the Angular dependency to `^2.0.0-rc.2` so we don't get warnings for every Angular RC update.