### PR TITLE
Added index.ts, improved documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ System.config({
 
 ```typescript
 ...
-import { ReCaptchaModule } from 'angular2-recaptcha/angular2-recaptcha';
+import { ReCaptchaModule } from 'angular2-recaptcha';
 ...
 ```
 
@@ -63,4 +63,11 @@ To catch the success callback, you will need to subscribe to `captchaResponse` e
 
 ```html
 <re-captcha (captchaResponse)="handleCorrectCaptcha($event)" site_key="<GOOGLE_RECAPTCHA_KEY>"></re-captcha>
+```
+
+The event `captchaExpired` is triggered when the displayed image has expired. It does not have any event parameters.
+
+You can request a new captcha to be displayed:
+```typescript
+ReCaptchaComponent::reset();
 ```

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export * from '.angular2-recaptcha';

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,1 @@
-export * from '.angular2-recaptcha';
+export * from './angular2-recaptcha';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-recaptcha",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Angular 2 : Typescript component for Google reCaptcha",
   "main": "angular2-recaptcha.js",
   "scripts": {


### PR DESCRIPTION
By having an index.ts exporting the component's module, we don't have to do `import * from 'angular2-recaptcha/angular2-recaptcha';` anymore but can just write `import * from 'angular2-recaptcha';` which is more familiar.