### PR TITLE
Fixing an issue with window being undefined for server side prerendering

### DIFF
--- a/lib/captcha.service.ts
+++ b/lib/captcha.service.ts
@@ -21,7 +21,9 @@ export class ReCaptchaService {
 
     constructor(zone: NgZone) {
         /* the callback needs to exist before the API is loaded */
-        window[<any>"reCaptchaOnloadCallback"] = <any>(() => zone.run(this.onloadCallback.bind(this)));
+		if (typeof window != 'undefined') {
+			window[<any>"reCaptchaOnloadCallback"] = <any>(() => zone.run(this.onloadCallback.bind(this)));
+		}
     }
 
     public getReady(language: string): Observable<boolean> {


### PR DESCRIPTION
I am using .Net Core 2 as a backend and am using this angular2-recapcha wrapper. It was working fine as long I haven't directly opened the page the widget is on, then it had window is undefined exception that crashed the page. After some investigation I have found out that it is caused by asp-prerender-module, I didn't want to disable prerendering, so I have found a solution. 
The fix is to do a check if window is available in the service constructor, it will prevent crash while page is prerendered (when window is unavailable), but still displays and works correctly when opened.