### PR TITLE
added loaded event Output()

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ Where **site_key** is the Google reCaptcha public key. Optional parameters as fo
 ## Callback
 
 To catch the success callback, you will need to subscribe to the `captchaResponse` event. The response token will be passed in the `$event` parameter.
+To wait for component be loaded subscribe to `loaded` event.
 
 ```html
-<re-captcha (captchaResponse)="handleCorrectCaptcha($event)" site_key="<GOOGLE_RECAPTCHA_KEY>"></re-captcha>
+<re-captcha (captchaResponse)="handleCorrectCaptcha($event)" (loaded)="sendCaptchaExecuteHere()" site_key="<GOOGLE_RECAPTCHA_KEY>"></re-captcha>
 ```
 
 The event `captchaExpired` is triggered when the displayed image has expired. It does not have any event parameters.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Where **site_key** is the Google reCaptcha public key. Optional parameters as fo
 ## Callback
 
 To catch the success callback, you will need to subscribe to the `captchaResponse` event. The response token will be passed in the `$event` parameter.
-To wait for component be loaded subscribe to `loaded` event.
+To wait for component to be loaded subscribe to `loaded` event.
 
 ```html
 <re-captcha (captchaResponse)="handleCorrectCaptcha($event)" (loaded)="sendCaptchaExecuteHere()" site_key="<GOOGLE_RECAPTCHA_KEY>"></re-captcha>

--- a/lib/captcha.component.ts
+++ b/lib/captcha.component.ts
@@ -65,7 +65,9 @@ export class ReCaptchaComponent implements OnInit, ControlValueAccessor {
                     'callback': <any>((response: any) => this._zone.run(this.recaptchaCallback.bind(this, response))),
                     'expired-callback': <any>(() => this._zone.run(this.recaptchaExpiredCallback.bind(this)))
                 });
-                this.loaded.emit(true);
+                setTimeout(() => {
+                    this.loaded.emit(true);                
+                }, 0);
             });
     }
 

--- a/lib/captcha.component.ts
+++ b/lib/captcha.component.ts
@@ -35,6 +35,7 @@ export class ReCaptchaComponent implements OnInit, ControlValueAccessor {
 
     @Output() captchaResponse = new EventEmitter<string>();
     @Output() captchaExpired = new EventEmitter();
+    @Output() loaded = new EventEmitter<boolean>();
 
     @ViewChild('target') targetRef: ElementRef;
     widgetId: any = null;
@@ -64,6 +65,7 @@ export class ReCaptchaComponent implements OnInit, ControlValueAccessor {
                     'callback': <any>((response: any) => this._zone.run(this.recaptchaCallback.bind(this, response))),
                     'expired-callback': <any>(() => this._zone.run(this.recaptchaExpiredCallback.bind(this)))
                 });
+                this.loaded.emit(true);
             });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-recaptcha",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Angular 6 component for Google reCaptcha",
   "main": "angular2-recaptcha.js",
   "scripts": {


### PR DESCRIPTION
fixed issue while sending execute request when `this.widgetId` is not initialized. 
now `execute()` will work on  `loaded` event callback.